### PR TITLE
Two small issues

### DIFF
--- a/crestic.py
+++ b/crestic.py
@@ -26,6 +26,8 @@ def main():
 
     config = configparser.ConfigParser()
     config.optionxform = str  # dont map config keys to lower case
+    with open(os.environ['CRESTIC_CONFIG_FILE']):
+        pass    # config.read() doesn't check exists and readable
     config.read(os.environ['CRESTIC_CONFIG_FILE'])
 
     sections = [

--- a/crestic.py
+++ b/crestic.py
@@ -6,6 +6,7 @@ import pathlib
 import argparse
 import subprocess
 import configparser
+import shlex
 
 
 def main():
@@ -56,6 +57,11 @@ def main():
     # Override config arguments with arguments from CLI
     if python_args.arguments:
         restic_options['arguments'] = python_args.arguments
+    elif restic_options.get('arguments'):
+        # convert to list
+        args = shlex.split(restic_options['arguments'])
+        # quote elements if needed
+        restic_options['arguments'] = [shlex.quote(arg) for arg in args]
 
     # Extract positional arguments from options dict
     try:


### PR DESCRIPTION
1) In some paths, restic_options['arguments'] is set to a list, in others a string.  This caused an error
when arguments: was a string larger than one byte.  (Do a dry run to see.)

2) The other change enables an error when a config file is specified, but doesn't exist or is not readable.