### PR TITLE
fail loudly if no valid config files/sections found

### DIFF
--- a/crestic.py
+++ b/crestic.py
@@ -130,6 +130,11 @@ def main(
     # dont map config keys to lower case
     config.optionxform = str  # type: ignore
     conffile_read = config.read(conffile)
+    if not config.sections():
+        print("crestic: no valid config sections found in file(s):", file=sys.stderr)
+        for path in conffile_read or conffile:
+            print(f"    {path}", file=sys.stderr)
+        return 1
 
     sections = [
         "global",

--- a/tests/nosections.cfg
+++ b/tests/nosections.cfg
@@ -1,0 +1,1 @@
+# Intentionally contains no sections; used by test_config_without_sections.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -64,6 +64,24 @@ def mock_parse_intermixed_args(request, monkeypatch):
     return request.param
 
 
+def test_no_config_file(mock_print, environ):
+    missing_cfg = ["/nonexistent/crestic/config.cfg"]
+    assert crestic.main(["plain", "backup"], conffile=missing_cfg, environ=environ) == 1
+
+    os.execvpe.assert_not_called()
+    builtins.print.assert_any_call(f"    {missing_cfg[0]}", file=sys.stderr)
+
+
+def test_config_without_sections(mock_print, environ):
+    nosections_cfg = [testroot + "/nosections.cfg"]
+    assert (
+        crestic.main(["plain", "backup"], conffile=nosections_cfg, environ=environ) == 1
+    )
+
+    os.execvpe.assert_not_called()
+    builtins.print.assert_any_call(f"    {nosections_cfg[0]}", file=sys.stderr)
+
+
 def test_plain_backup(conffile, environ):
     crestic.main(["plain", "backup"], conffile=conffile, environ=environ)
     os.execvpe.assert_called_once_with(


### PR DESCRIPTION
After attempting to read/parse all config files, validate that something resembling a config (having a non default section) has been found. If not, avoid the footgun of continuing on to restic with an empty config.

Reasoning: If user wants to run restic empty, they should probably run restic directly. User called crestic so it's most likely a misconfig or absent envvar.